### PR TITLE
fixed: add `__init__.py` file

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,3 @@
+from .node_openvino import NODE_CLASS_MAPPINGS
+
+__all__ = ['NODE_CLASS_MAPPINGS']


### PR DESCRIPTION
Add an `__init__.py` file to allow installation in the form of subdiectories under `custom_nodes`.